### PR TITLE
fix(backend): add batch catalog resolve API and reduce quote catalog …

### DIFF
--- a/app/crud/catalog.py
+++ b/app/crud/catalog.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Tuple
 from sqlalchemy.orm import Session
-from sqlalchemy import and_, or_, func
+from sqlalchemy import and_
 from datetime import datetime
 import math
 
@@ -112,6 +112,18 @@ class CRUDCatalogItem(CRUDBase[CatalogItem, CatalogItemCreate, CatalogItemUpdate
 
         return items, total_count
 
+    def get_multi_by_ids(self, db: Session, *, ids: List[str]) -> List[CatalogItem]:
+        if not ids:
+            return []
+        return (
+            db.query(self.model)
+            .filter(
+                self.model.id.in_(ids),
+                self.model.deleted_at.is_(None),
+            )
+            .all()
+        )
+
     def create_with_item_no(self, db: Session, *, obj_in: CatalogItemCreate) -> CatalogItem:
         """
         Create catalog item with auto-generated item_no.
@@ -205,4 +217,3 @@ class CRUDCatalogItem(CRUDBase[CatalogItem, CatalogItemCreate, CatalogItemUpdate
 
 
 catalog = CRUDCatalogItem(CatalogItem)
-

--- a/app/routers/catalog.py
+++ b/app/routers/catalog.py
@@ -137,6 +137,30 @@ def create_catalog_item(
         raise HTTPException(status_code=409, detail=str(e))
 
 
+@router.post("/resolve", response_model=list[schemas.CatalogItemResolveItem])
+def resolve_catalog_items(
+    *,
+    db: Session = Depends(get_db),
+    request: schemas.CatalogItemResolveRequest,
+) -> Any:
+    """
+    Batch resolve lightweight catalog metadata for quote/rfq editing flows.
+    Returns only the fields needed by the frontend to avoid N detail calls.
+    """
+    unique_ids = list(dict.fromkeys(request.ids))
+    if not unique_ids:
+        return []
+
+    items = crud.catalog.get_multi_by_ids(db, ids=unique_ids)
+    item_map = {item.id: item for item in items}
+
+    return [
+        schemas.CatalogItemResolveItem.model_validate(item_map[item_id])
+        for item_id in unique_ids
+        if item_id in item_map
+    ]
+
+
 @router.get("/{id}", response_model=schemas.CatalogItemPublic)
 def read_catalog_item(
     *,

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -9,6 +9,8 @@ from .catalog import (
     CatalogItemListResponse,
     CatalogItemInternalListResponse,
     CatalogItemMeta,
+    CatalogItemResolveRequest,
+    CatalogItemResolveItem,
 )
 from .tax_category import TaxCategory, TaxCategoryCreate, TaxCategoryUpdate
 from .unit import Unit, UnitCreate, UnitUpdate

--- a/app/schemas/catalog.py
+++ b/app/schemas/catalog.py
@@ -87,5 +87,21 @@ class CatalogItemInternalListResponse(BaseModel):
     items: List[CatalogItemInternal]
     meta: CatalogItemMeta
 
+
+class CatalogItemResolveRequest(BaseModel):
+    ids: List[str]
+
+
+class CatalogItemResolveItem(BaseModel):
+    id: str
+    name: str
+    type: Literal["product", "service", "output"]
+    unit: str
+    category: Optional[str] = None
+    default_price: Decimal
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 # Backward-compatible alias
 CatalogItem = CatalogItemPublic

--- a/tests/test_catalog_resolve_api.py
+++ b/tests/test_catalog_resolve_api.py
@@ -1,0 +1,79 @@
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.deps.auth import get_current_user
+from app.main import app
+
+
+@pytest.fixture()
+def client():
+    def override_db():
+        yield SimpleNamespace()
+
+    def override_current_user():
+        return SimpleNamespace(id="test-user")
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+    app.dependency_overrides.clear()
+
+
+def test_catalog_resolve_returns_batch_metadata_and_price(client, monkeypatch):
+    from app.routers import catalog as catalog_router
+
+    monkeypatch.setattr(
+        catalog_router.crud.catalog,
+        "get_multi_by_ids",
+        lambda db, ids: [
+            SimpleNamespace(
+                id="item-2",
+                name="Catalog B",
+                type="service",
+                unit="set",
+                category="labor",
+                default_price=Decimal("2200.00"),
+            ),
+            SimpleNamespace(
+                id="item-1",
+                name="Catalog A",
+                type="product",
+                unit="pcs",
+                category="panel",
+                default_price=Decimal("1500.00"),
+            ),
+        ],
+    )
+
+    response = client.post(
+        "/api/v1/catalog-items/resolve",
+        json={"ids": ["item-1", "item-2", "missing-item"]},
+        headers={"x-csrf-token": "test-token"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": "item-1",
+            "name": "Catalog A",
+            "type": "product",
+            "unit": "pcs",
+            "category": "panel",
+            "default_price": "1500.00",
+        },
+        {
+            "id": "item-2",
+            "name": "Catalog B",
+            "type": "service",
+            "unit": "set",
+            "category": "labor",
+            "default_price": "2200.00",
+        },
+    ]


### PR DESCRIPTION
…query fan-out

Change Summary

這條適合 backend 那包：/catalog-items/resolve、quote save/read 的 batch resolve、category snapshot、promotion 驗證降 fan-out。 方向是把 per-item catalog query 改成 batch，避免 DB pool 再被打滿。